### PR TITLE
Fixed bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
         2. ...
         3. ...
     validations:
-      - required: true
+      required: true
   - type: textarea
     id: solution
     attributes:


### PR DESCRIPTION
This fixes `body[0]: validations must be of type Hash` parsing error :sparkles: